### PR TITLE
Fix firmware dependency in control file

### DIFF
--- a/control
+++ b/control
@@ -1,7 +1,7 @@
 Package: jp.akusio.kernbypass
 Name: KernBypass
 Version: 0.0.3
-Depends: mobilesubstrate, applist, preferenceloader, Firmware(>=12.0)
+Depends: mobilesubstrate, applist, preferenceloader, firmware(>=12.0)
 Architecture: iphoneos-arm
 Description: kernel level jailbreak detection bypass.
 Depiction: http://akusio.github.io/descriptions/kernbypass/index.html


### PR DESCRIPTION
The package's name is lowercase. It works either way in Cydia because it parses dependencies as case-insensitive, but some other package managers like Sileo fail on the capital `Firmware` dependency.

Also, it's not valid to have a capital letter in a package name anyway:

> Package names (both source and binary, see Package) must consist only of lower case letters (a-z), digits (0-9), plus (+) and minus (-) signs, and periods (.). They must be at least two characters long and must start with an alphanumeric character.

https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-source